### PR TITLE
Expose syscall flags, introduce accept4, get/set_inheritable, IPv6 test, use winapi crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,7 @@ keywords = ["socket"]
 
 [target."cfg(unix)".dependencies]
 libc = "^0.2.20"
+
+[target."cfg(windows)".dependencies]
+winapi     = "^0.2.8"
+ws2_32-sys = "^0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 keywords = ["socket"]
 
 [dependencies]
+bitflags = "^0.8"
 
 [target."cfg(unix)".dependencies]
 libc = "^0.2.20"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,6 @@ keywords = ["socket"]
 libc = "^0.2.20"
 
 [target."cfg(windows)".dependencies]
-winapi     = "^0.2.8"
-ws2_32-sys = "^0.2.1"
+kernel32-sys = "^0.2.2"
+winapi       = "^0.2.8"
+ws2_32-sys   = "^0.2.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
 ///!Raw Socket API
 
+#[macro_use]
+extern crate bitflags;
+
 pub mod raw;

--- a/src/raw/unix.rs
+++ b/src/raw/unix.rs
@@ -373,7 +373,7 @@ impl Socket {
                 //  * Another thread causing havok with random file descriptors
                 //    (always very bad and nothing, particularily since there is absolutely nothing
                 //     that we OR THE CALLER can do about this)
-                sock.set_nonblocking( flags.contains(NON_BLOCKING)).expect("Setting newly obtained client socket blocking mode");
+                sock.set_blocking(!flags.contains(NON_BLOCKING)).expect("Setting newly obtained client socket blocking mode");
                 sock.set_inheritable(!flags.contains(NON_INHERITABLE)).expect("Setting newly obtained client socket inheritance mode");
 
                 (sock, addr)
@@ -457,8 +457,8 @@ impl Socket {
     }
 
     ///Sets non-blocking mode.
-    pub fn set_nonblocking(&self, value: bool) -> io::Result<()> {
-        self.ioctl(FIONBIO, value as c_ulong)
+    pub fn set_blocking(&self, value: bool) -> io::Result<()> {
+        self.ioctl(FIONBIO, (!value) as c_ulong)
     }
 
 

--- a/src/raw/unix.rs
+++ b/src/raw/unix.rs
@@ -133,14 +133,14 @@ macro_rules! impl_into_trait {
     };
 }
 
-#[allow(non_snake_case)]
+#[allow(non_snake_case, non_upper_case_globals)]
 ///Socket family
 pub mod Family {
     use super::libc::*;
     pub const UNSPECIFIED: c_int = AF_UNSPEC;
     pub const UNIX: c_int = AF_UNIX;
-    pub const IPV4: c_int = AF_INET;
-    pub const IPV6: c_int = AF_INET6;
+    pub const IPv4: c_int = AF_INET;
+    pub const IPv6: c_int = AF_INET6;
     #[cfg(not(target_os = "macos"))]
     pub const NETLINK: c_int = AF_NETLINK;
     #[cfg(not(target_os = "macos"))]
@@ -163,17 +163,18 @@ pub mod Type {
     pub const CLOEXEC: c_int = SOCK_CLOEXEC;
 }
 
-#[allow(non_snake_case)]
+#[allow(non_snake_case, non_upper_case_globals)]
 ///Socket protocol
 pub mod Protocol {
     use super::libc::*;
     pub const NONE: c_int = 0;
-    pub const ICMP: c_int = 1;
+    pub const ICMPv4: c_int = 1;
     pub const TCP: c_int = 6;
     pub const UDP: c_int = 17;
-    pub const ICMPV6: c_int = 58;
+    pub const ICMPv6: c_int = 58;
 }
 
+#[repr(i32)]
 #[derive(Copy, Clone)]
 ///Type of socket's shutdown operation.
 pub enum ShutdownType {

--- a/src/raw/unix.rs
+++ b/src/raw/unix.rs
@@ -497,6 +497,20 @@ impl Socket {
         Ok(())
     }
 
+	///Returns whether this will be inherited by newly created processes or not.
+	///
+	///See `set_inheritable` for a detailed description of what this means.
+	pub fn get_inheritable(&self) -> io::Result<bool> {
+		unsafe {
+            let flags: libc::c_int = libc::fcntl(self.inner, libc::F_GETFD);
+            if flags < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            
+            Ok((flags & libc::FD_CLOEXEC) == 0)
+        }
+	}
+
 
     ///Stops receive and/or send over socket.
     pub fn shutdown(&self, direction: ShutdownType) -> io::Result<()> {

--- a/src/raw/windows.rs
+++ b/src/raw/windows.rs
@@ -103,7 +103,10 @@ mod winapi {
     // Currently not available in `winapi`.
     pub const HANDLE_FLAG_INHERIT: winapi::DWORD = 1;
 
-    pub use self::kernel32::SetHandleInformation;
+    pub use self::kernel32::{
+    	SetHandleInformation,
+    	GetHandleInformation
+    };
 }
 
 
@@ -466,6 +469,18 @@ impl Socket {
             }
         }
     }
+
+
+	///Returns whether this socket will be inherited by child processes or not.
+	pub fn get_inheritable(&self) -> io::Result<bool> {
+		unsafe {
+			let mut flags: winapi::DWORD = 0;
+			match winapi::GetHandleInformation(self.inner as winapi::HANDLE, &mut flags as *mut _) {
+                0 => Err(io::Error::last_os_error()),
+                _ => Ok((flags & winapi::HANDLE_FLAG_INHERIT) != 0)
+            }
+        }
+	}
 
 
     ///Stops receive and/or send over socket.

--- a/src/raw/windows.rs
+++ b/src/raw/windows.rs
@@ -271,10 +271,10 @@ impl Socket {
     ///Receives some bytes from socket
     ///
     ///Number of received bytes is returned on success
-    pub fn recv(&self, buf: &mut [u8]) -> io::Result<usize> {
+    pub fn recv(&self, buf: &mut [u8], flags: c_int) -> io::Result<usize> {
         let len = cmp::min(buf.len(), i32::max_value() as usize) as i32;
         unsafe {
-            match winapi::recv(self.inner, buf.as_mut_ptr() as *mut c_char, len, 0) {
+            match winapi::recv(self.inner, buf.as_mut_ptr() as *mut c_char, len, flags) {
                 -1 => {
                     let error = io::Error::last_os_error();
                     let raw_code = error.raw_os_error().unwrap();
@@ -294,13 +294,13 @@ impl Socket {
     ///Receives some bytes from socket
     ///
     ///Number of received bytes and remote address are returned on success.
-    pub fn recv_from(&self, buf: &mut [u8]) -> io::Result<(usize, net::SocketAddr)> {
+    pub fn recv_from(&self, buf: &mut [u8], flags: c_int) -> io::Result<(usize, net::SocketAddr)> {
         let len = cmp::min(buf.len(), i32::max_value() as usize) as i32;
         unsafe {
             let mut storage: winapi::SOCKADDR_STORAGE_LH = mem::zeroed();
             let mut storage_len = mem::size_of_val(&storage) as c_int;
 
-            match winapi::recvfrom(self.inner, buf.as_mut_ptr() as *mut c_char, len, 0, &mut storage as *mut _ as *mut _, &mut storage_len) {
+            match winapi::recvfrom(self.inner, buf.as_mut_ptr() as *mut c_char, len, flags, &mut storage as *mut _ as *mut _, &mut storage_len) {
                 -1 => {
                     let error = io::Error::last_os_error();
                     let raw_code = error.raw_os_error().unwrap();
@@ -324,11 +324,11 @@ impl Socket {
     ///Sends some bytes through socket.
     ///
     ///Number of sent bytes is returned.
-    pub fn send(&self, buf: &[u8]) -> io::Result<usize> {
+    pub fn send(&self, buf: &[u8], flags: c_int) -> io::Result<usize> {
         let len = cmp::min(buf.len(), i32::max_value() as usize) as i32;
 
         unsafe {
-            match winapi::send(self.inner, buf.as_ptr() as *const c_char, len, 0) {
+            match winapi::send(self.inner, buf.as_ptr() as *const c_char, len, flags) {
                 -1 => {
                     let error = io::Error::last_os_error();
                     let raw_code = error.raw_os_error().unwrap();
@@ -351,12 +351,12 @@ impl Socket {
     ///
     ///Note: the socket will be bound, if it isn't already.
     ///Use method `name` to determine address.
-    pub fn send_to(&self, buf: &[u8], peer_addr: &net::SocketAddr) -> io::Result<usize> {
+    pub fn send_to(&self, buf: &[u8], peer_addr: &net::SocketAddr, flags: c_int) -> io::Result<usize> {
         let len = cmp::min(buf.len(), i32::max_value() as usize) as i32;
         let (addr, addr_len) = get_raw_addr(peer_addr);
 
         unsafe {
-            match winapi::sendto(self.inner, buf.as_ptr() as *const c_char, len, 0, addr, addr_len) {
+            match winapi::sendto(self.inner, buf.as_ptr() as *const c_char, len, flags, addr, addr_len) {
                 -1 => {
                     let error = io::Error::last_os_error();
                     let raw_code = error.raw_os_error().unwrap();

--- a/src/raw/windows.rs
+++ b/src/raw/windows.rs
@@ -365,15 +365,15 @@ impl Socket {
     ///Accept a new incoming client connection and return its files descriptor and address.
     ///
     ///This is an emulation of the corresponding Unix system call, that will automatically call
-    ///`.set_nonblocking` and `.set_inheritable` with parameter values based on the value of
-    ///`flags` on the created client socket:
+    ///`.set_blocking` and `.set_inheritable` with parameter values based on the value of `flags`
+    ///on the created client socket:
     ///
     /// * `AcceptFlags::NON_BLOCKING`    – Mark the newly created socket as non-blocking
     /// * `AcceptFlags::NON_INHERITABLE` – Mark the newly created socket as not inheritable by client processes
     pub fn accept4(&self, flags: AcceptFlags) -> io::Result<(Socket, net::SocketAddr)> {
         self.accept().map(|(sock, addr)| {
             // Emulate the two most common (and useful) `accept4` flags
-            sock.set_nonblocking( flags.contains(NON_BLOCKING)).expect("Setting newly obtained client socket blocking mode");
+            sock.set_blocking(!flags.contains(NON_BLOCKING)).expect("Setting newly obtained client socket blocking mode");
             sock.set_inheritable(!flags.contains(NON_INHERITABLE)).expect("Setting newly obtained client socket inheritance mode");
 
             (sock, addr)
@@ -452,8 +452,8 @@ impl Socket {
     }
 
     ///Sets non-blocking mode.
-    pub fn set_nonblocking(&self, value: bool) -> io::Result<()> {
-        self.ioctl(winapi::FIONBIO as c_int, value as c_ulong)
+    pub fn set_blocking(&self, value: bool) -> io::Result<()> {
+        self.ioctl(winapi::FIONBIO as c_int, (!value) as c_ulong)
     }
 
 

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -181,7 +181,7 @@ fn socket_test_tcp6() {
         let mut buf = [0; 10];
         let result = result_socket.recv(&mut buf, 0);
         assert!(result.is_err() && result.unwrap_err().kind() == std::io::ErrorKind::WouldBlock);
-        assert!(result_socket.set_nonblocking(false).is_ok());
+        assert!(result_socket.set_blocking(true).is_ok());
 
         let result = result_socket.recv(&mut buf, 0);
 
@@ -233,10 +233,10 @@ fn socket_test_options() {
     #[cfg(not(target_os = "macos"))]
     assert_eq!(result.unwrap(), value_true);
 
-    assert!(socket.set_nonblocking(true).is_ok());
-    assert!(socket.set_inheritable(true).is_ok());
-    assert!(socket.set_nonblocking(false).is_ok());
+    assert!(socket.set_blocking(false).is_ok());
     assert!(socket.set_inheritable(false).is_ok());
+    assert!(socket.set_blocking(true).is_ok());
+    assert!(socket.set_inheritable(true).is_ok());
 }
 
 #[cfg(windows)]
@@ -295,7 +295,7 @@ fn socket_select_timeout() {
 
     let client = Socket::new(Family::IPv4, Type::STREAM, Protocol::TCP).unwrap();
 
-    assert!(client.set_nonblocking(true).is_ok());
+    assert!(client.set_blocking(false).is_ok());
     let result = client.connect(&server_addr);
     assert!(result.is_err()); //Non-blocking connect returns error
     assert_eq!(result.err().unwrap().raw_os_error().unwrap(), would_block_errno);
@@ -333,7 +333,7 @@ fn socket_select_connect() {
         assert!(result.is_ok());
     });
 
-    assert!(client.set_nonblocking(true).is_ok());
+    assert!(client.set_blocking(false).is_ok());
     let result = client.connect(&server_addr);
     assert!(result.is_err()); //Non-blocking connect returns error
     assert_eq!(result.err().unwrap().raw_os_error().unwrap(), would_block_errno);

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -173,6 +173,11 @@ fn socket_test_tcp6() {
 
         assert_eq!(result_addr, client_addr);
 
+        // Check whether the `NON_INHERITABLE` flag worked
+        let result = result_socket.get_inheritable();
+        assert!(result.is_ok() && result.unwrap() == false);
+
+		// Check whether the `NON_BLOCKING` flag worked
         let mut buf = [0; 10];
         let result = result_socket.recv(&mut buf, 0);
         assert!(result.is_err() && result.unwrap_err().kind() == std::io::ErrorKind::WouldBlock);
@@ -229,7 +234,9 @@ fn socket_test_options() {
     assert_eq!(result.unwrap(), value_true);
 
     assert!(socket.set_nonblocking(true).is_ok());
+    assert!(socket.set_inheritable(true).is_ok());
     assert!(socket.set_nonblocking(false).is_ok());
+    assert!(socket.set_inheritable(false).is_ok());
 }
 
 #[cfg(windows)]

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -267,7 +267,7 @@ fn socket_select_connect() {
 
     let server = Socket::new(family, ty, proto).unwrap();
     assert!(server.bind(&server_addr).is_ok());
-    assert!(server.listen(0).is_ok());
+    server.listen(0).unwrap();
 
     let client = Socket::new(family, ty, proto).unwrap();
 

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -60,7 +60,7 @@ fn socket_test_udp() {
     assert!(client.bind(&net::SocketAddr::from_str("127.0.0.1:5666").unwrap()).is_ok());
     let client_addr = client.name().unwrap();
 
-    let result = client.send_to(&data, &addr);
+    let result = client.send_to(&data, &addr, 0);
     assert!(result.is_ok());
     let result = result.unwrap();
     assert_eq!(result, data.len());
@@ -68,7 +68,7 @@ fn socket_test_udp() {
     let mut read_data = [0; 10];
 
     // recv_from
-    let result = server.recv_from(&mut read_data);
+    let result = server.recv_from(&mut read_data, 0);
     assert!(result.is_ok());
     let (result_len, result_addr) = result.unwrap();
 
@@ -78,24 +78,24 @@ fn socket_test_udp() {
     assert_eq!(&read_data[..result_len], data);
 
     // 2 send + 2 recv
-    let result = client.send_to(&data, &addr);
+    let result = client.send_to(&data, &addr, 0);
     assert!(result.is_ok());
     let result = result.unwrap();
     assert_eq!(result, data.len());
 
-    let result = client.send_to(&data, &addr);
+    let result = client.send_to(&data, &addr, 0);
     assert!(result.is_ok());
     let result = result.unwrap();
     assert_eq!(result, data.len());
 
-    let result = server.recv(&mut read_data);
+    let result = server.recv(&mut read_data, 0);
     assert!(result.is_ok());
     let result_len = result.unwrap();
     assert_eq!(result_len, data.len());
     assert_eq!(read_data[result_len], 0);
     assert_eq!(&read_data[..result_len], data);
 
-    let result = server.recv(&mut read_data);
+    let result = server.recv(&mut read_data, 0);
     assert!(result.is_ok());
     let result_len = result.unwrap();
     assert_eq!(result_len, data.len());
@@ -131,7 +131,7 @@ fn socket_test_tcp() {
         assert_eq!(result_addr, client_addr);
 
         let mut buf = [0; 10];
-        let result = result_socket.recv(&mut buf);
+        let result = result_socket.recv(&mut buf, 0);
         assert!(result.is_ok());
         let result_len = result.unwrap();
         assert_eq!(result_len, data.len());
@@ -141,7 +141,7 @@ fn socket_test_tcp() {
 
     let result = client.connect(&server_addr);
     assert!(result.is_ok());
-    assert!(client.send(&data).is_ok());
+    assert!(client.send(&data, 0).is_ok());
 
     assert!(th.join().is_ok());
 }

--- a/tests/socket.rs
+++ b/tests/socket.rs
@@ -14,7 +14,7 @@ fn socket_new_raw_icmp() {
     //Test requires admin privileges.
     let addr = net::SocketAddr::from_str("0.0.0.0:0").unwrap();
 
-    let socket = Socket::new(Family::IPV4, Type::RAW, Protocol::ICMP);
+    let socket = Socket::new(Family::IPv4, Type::RAW, Protocol::ICMPv4);
 
     if let Err(error) = socket {
         let error_code = error.raw_os_error().unwrap();
@@ -45,7 +45,7 @@ fn socket_new_raw_icmp() {
 
 #[test]
 fn socket_test_udp() {
-    let family = Family::IPV4;
+    let family = Family::IPv4;
     let ty = Type::DATAGRAM;
     let proto = Protocol::UDP;
     let data = [1, 2, 3, 4];
@@ -105,7 +105,7 @@ fn socket_test_udp() {
 
 #[test]
 fn socket_test_tcp() {
-    let family = Family::IPV4;
+    let family = Family::IPv4;
     let ty = Type::STREAM;
     let proto = Protocol::TCP;
     let data = [1, 2, 3, 4];
@@ -158,7 +158,7 @@ fn socket_test_options() {
     #[cfg(unix)]
     let name: c_int = libc::SO_REUSEADDR; //SO_REUSEADDR
 
-    let socket = Socket::new(Family::IPV4, Type::STREAM, Protocol::TCP).unwrap();
+    let socket = Socket::new(Family::IPv4, Type::STREAM, Protocol::TCP).unwrap();
 
     let result = socket.get_opt::<c_int>(level, name);
     assert!(result.is_ok());
@@ -194,7 +194,7 @@ fn socket_as_into_from_traits() {
     let raw_socket;
 
     {
-        let socket = Socket::new(Family::IPV4, Type::STREAM, Protocol::TCP).unwrap();
+        let socket = Socket::new(Family::IPv4, Type::STREAM, Protocol::TCP).unwrap();
         raw_socket = socket.into_raw_socket();
     }
 
@@ -216,7 +216,7 @@ fn socket_as_into_from_traits() {
     let raw_socket;
 
     {
-        let socket = Socket::new(Family::IPV4, Type::STREAM, Protocol::TCP).unwrap();
+        let socket = Socket::new(Family::IPv4, Type::STREAM, Protocol::TCP).unwrap();
         raw_socket = socket.into_raw_fd();
     }
 
@@ -236,7 +236,7 @@ fn socket_select_timeout() {
 
     let server_addr = net::SocketAddr::from_str("222.0.0.1:60004").unwrap();
 
-    let client = Socket::new(Family::IPV4, Type::STREAM, Protocol::TCP).unwrap();
+    let client = Socket::new(Family::IPv4, Type::STREAM, Protocol::TCP).unwrap();
 
     assert!(client.set_nonblocking(true).is_ok());
     let result = client.connect(&server_addr);
@@ -260,7 +260,7 @@ fn socket_select_connect() {
     #[cfg(unix)]
     let would_block_errno = libc::EINPROGRESS;
 
-    let family = Family::IPV4;
+    let family = Family::IPv4;
     let ty = Type::STREAM;
     let proto = Protocol::TCP;
     let server_addr = net::SocketAddr::from_str("127.0.0.1:60006").unwrap();


### PR DESCRIPTION
I like what you are doing with this library, but I'm missing some features/options that I think ought to be available. Therefor all but one commit are BREAKING CHANGES and you may not agree on the way I've implemented some of these things.

Changes right now, in particular, are:

  * Add flags parameter to `send*` and `recv*`
  * Update Windows codebase to use `winapi` and friends instead of the current homebrew approach
  * Add support for a Python-style `set_inheritable` (the code is a 1:1 translation from the CPython code base as well, btw)
  * Add a flags parameter to `accept` INCLUDING EMULATION for systems that do not (yet) have the corresponding `accept4` system call
    - Without this one is pretty much forced to always use `set_blocking` and `set_inheritable` manually, if portable blocking and inheritance behaviour for the created file descriptor is desired

Things still missing:

  * TESTS!
  * ~CI for macOS and Windowse~
  * Replace `std::net::SocketAddr` with something that describe all supported operating system socket address types, not just IPv4 and IPv6

Please let me know your thoughts on this and whether you think that this is something that aligns with your ideas on what this library should be.